### PR TITLE
Match more emojis

### DIFF
--- a/lib/helper/parse-commits.js
+++ b/lib/helper/parse-commits.js
@@ -1,5 +1,5 @@
 const issueRegex = require('issue-regex')
-const emojiRegex = require('emoji-regex')
+const emojiRegex = require('emoji-regex/text')
 const { emojify } = require('node-emoji')
 
 const resolveIssueRef = require('./resolve-issue-ref')

--- a/test/integration/generate-notes.test.js
+++ b/test/integration/generate-notes.test.js
@@ -13,7 +13,7 @@ const now = new Date()
 
 function readNotesSync (name) {
   return readFileSync(path.join(__dirname, 'fixtures', 'notes', `notes-${name}.md`), 'utf8')
-    .replace(/\{datetime\}/g, dateFormat(now, 'yyyy-mm-dd'))
+    .replace(/\{datetime\}/g, dateFormat(now, 'UTC:yyyy-mm-dd'))
 }
 
 const stub = sinon.stub(ReleaseNotes, 'get')


### PR DESCRIPTION
Updates the `parseGitmoji` function to use the text regex from `emoji-regex`, which correctly matches additional emojis (:label:, for example) that are missed by the default regex. See https://github.com/mathiasbynens/emoji-regex/issues/44 for context

Also, fixes a bug in the release notes tests that occurred while trying to run them locally.