### PR TITLE
:memo: Add Missing Comma in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ module.exports = {
             datetime: function (format = 'UTC:yyyy-mm-dd') {
               return dateFormat(new Date(), format)
             }
-          }
+          },
           issueResolution: {
             template: '{baseUrl}/{owner}/{repo}/issues/{ref}',
             baseUrl: 'https://github.com',


### PR DESCRIPTION
The sample export for ".releaserc.js" or "release.config.js" is missing a comma before the `issueResolution` property. I noticed this while setting up a new project, so I thought I'd open a PR in case anyone else starts with a copy-paste.