### PR TITLE
:arrow_up: Upgrade gitmojis to 3.13.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "debug": "^4.3.2",
         "emoji-regex": "^9.2.2",
         "git-url-parse": "^13.0.0",
-        "gitmojis": "^3.13.1",
+        "gitmojis": "^3.13.4",
         "handlebars": "^4.7.6",
         "issue-regex": "^3.1.0",
         "lodash.clonedeep": "^4.5.0",
@@ -3977,9 +3977,9 @@
       }
     },
     "node_modules/gitmojis": {
-      "version": "3.13.1",
-      "resolved": "https://registry.npmjs.org/gitmojis/-/gitmojis-3.13.1.tgz",
-      "integrity": "sha512-HA9iV+NBT8UR3T8LlUgPtvMKcBJa7RKenljoJhScWT/0gaggeQtyqXbPzLTv3u6BptTNOdadFDV5PiXMUDn2+g=="
+      "version": "3.13.4",
+      "resolved": "https://registry.npmjs.org/gitmojis/-/gitmojis-3.13.4.tgz",
+      "integrity": "sha512-TRYhqnD36Xs9GHuATVRmo7hzBb+6wXYC0zxBFvLs3nma7N1WQGWW2vPTQ0+3GsGcPwSp0XVGfe3Besn4a6ip5Q=="
     },
     "node_modules/glob": {
       "version": "7.2.0",
@@ -14623,9 +14623,9 @@
       }
     },
     "gitmojis": {
-      "version": "3.13.1",
-      "resolved": "https://registry.npmjs.org/gitmojis/-/gitmojis-3.13.1.tgz",
-      "integrity": "sha512-HA9iV+NBT8UR3T8LlUgPtvMKcBJa7RKenljoJhScWT/0gaggeQtyqXbPzLTv3u6BptTNOdadFDV5PiXMUDn2+g=="
+      "version": "3.13.4",
+      "resolved": "https://registry.npmjs.org/gitmojis/-/gitmojis-3.13.4.tgz",
+      "integrity": "sha512-TRYhqnD36Xs9GHuATVRmo7hzBb+6wXYC0zxBFvLs3nma7N1WQGWW2vPTQ0+3GsGcPwSp0XVGfe3Besn4a6ip5Q=="
     },
     "glob": {
       "version": "7.2.0",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "debug": "^4.3.2",
     "emoji-regex": "^9.2.2",
     "git-url-parse": "^13.0.0",
-    "gitmojis": "^3.13.1",
+    "gitmojis": "^3.13.4",
     "handlebars": "^4.7.6",
     "issue-regex": "^3.1.0",
     "lodash.clonedeep": "^4.5.0",


### PR DESCRIPTION
Fixes: #59 
Gitmojis 3.13.4 supports esm and cjs projects.