### PR TITLE
✨ Add support for custom commit URLs and issue resolution

### DIFF
--- a/.releaserc.js
+++ b/.releaserc.js
@@ -18,6 +18,14 @@ module.exports = {
         },
         releaseNotes: {
           template: fs.readFileSync(tplFile, 'utf-8'),
+          commitUrlTemplate: 'https://{source}/{owner}/{repo}/commit/{commit.commit.short}',
+        },
+        issueResolution: {
+          template: '{baseUrl}/{owner}/{repo}/issues/{ref}',
+          baseUrl: 'https://github.com',
+          source: 'github.com',
+          removeFromCommit: false,
+          regex: /#\d+/g
         }
       }
     ],

--- a/lib/assets/default-config.js
+++ b/lib/assets/default-config.js
@@ -26,6 +26,7 @@ module.exports = {
   releaseNotes: {
     semver: false,
     template: readFileAsync(path.join(TEMPLATE_DIR, 'default-template.hbs')),
+    commitUrlTemplate: 'https://{source}/{owner}/{repo}/commit/{commit}',
     partials: {
       commitTemplate: readFileAsync(path.join(TEMPLATE_DIR, 'commit-template.hbs'))
     },

--- a/lib/assets/templates/commit-template.hbs
+++ b/lib/assets/templates/commit-template.hbs
@@ -1,3 +1,3 @@
-[`{{commit.short}}`](https://github.com/{{owner}}/{{repo}}/commit/{{commit.short}}) {{subject}} {{#if issues}}(Issues:{{#each issues}} [`{{text}}`]({{link}}){{/each}}){{/if}}{{#if wip}}{{#each wip}}
-    - [`{{commit.short}}`](https://github.com/{{owner}}/{{repo}}/commit/{{commit.short}}) {{subject}}{{/each}}
+[`{{commit.short}}`]({{url}}) {{subject}} {{#if issues}}(Issues:{{#each issues}} [`{{text}}`]({{link}}){{/each}}){{/if}}{{#if wip}}{{#each wip}}
+    - [`{{commit.short}}`]({{url}}) {{subject}}{{/each}}
 {{/if}}

--- a/lib/helper/get-cmp-link.js
+++ b/lib/helper/get-cmp-link.js
@@ -3,6 +3,10 @@ module.exports = function getCmpLink (host, owner, repo, prevTag, nextTag) {
   switch (host) {
     case 'github.com':
       return `https://github.com/${owner}/${repo}/compare/${prevTag}...${nextTag}`
+    case 'gitlab.com':
+      return `https://gitlab.com/${owner}/${repo}/compare/${prevTag}...${nextTag}`
+    case 'bitbucket.org':
+      return `https://bitbucket.org/${owner}/${repo}/compare/${nextTag}..${prevTag}`
     default:
       return ''
   }

--- a/lib/helper/get-config.js
+++ b/lib/helper/get-config.js
@@ -33,6 +33,12 @@ function handleArrayConfig (dest, src) {
 module.exports = function getConfig (userConfig) {
   if (userConfig && 'releaseNotes' in userConfig && 'semver' in userConfig.releaseNotes && userConfig.releaseNotes.semver) {
     DEFAULT_CONFIG.releaseNotes.template = readFileAsync(path.join(TEMPLATE_DIR, 'default-template-semver.hbs'))
+    console.log('config:semver')
+    console.table(userConfig)
+  } else {
+    console.log('config:')
+    console.table(userConfig)
   }
+
   return _mergeWith(_cloneDeep(DEFAULT_CONFIG), userConfig, handleArrayConfig)
 }

--- a/lib/release-notes.js
+++ b/lib/release-notes.js
@@ -27,14 +27,16 @@ const RELEASE_TYPES = require('./assets/release-types.json')
 module.exports = class ReleaseNotes {
   /**
    * @param {object} context
-   */
-  constructor (context, { issueResolution, template, partials, helpers, semver } = {}) {
-    debug('Found %d commits', context.commits.length)
+   */  
+  constructor (context, { issueResolution, commitUrlTemplate, commitBaseUrl, template, partials, helpers, semver } = {}) {
+    debug('Found %d commits', Object.keys(context.commits).length)
 
     const { owner, name: repo, source } = parseGitUrl(context.options.repositoryUrl)
 
     debug('Git remote: %s', source)
     debug('Repository: %s/%s', owner, repo)
+
+    console.table(context)
 
     this._semver = semver
     this._template = template
@@ -46,14 +48,27 @@ module.exports = class ReleaseNotes {
       ...helpers
     }
 
+    const parsedCommits = parseCommits(context.commits, { owner, repo, source, commitBaseUrl }, {
+      issues: { owner, repo, source, ...issueResolution },
+      semver: this._semver
+    })
+
     this._context = {
       owner,
       repo,
       source,
-      commits: parseCommits(context.commits, { owner, repo, source }, {
-        issues: { owner, repo, source, ...issueResolution },
-        semver: this._semver
-      })
+      commits: Object.entries(parsedCommits).reduce((acc, [key, commits]) => {
+        acc[key] = commits.map(commit => {
+          return {
+            ...commit,
+            url: commitUrlTemplate.replace('{source}', source)
+              .replace('{owner}', owner)
+              .replace('{repo}', repo)
+              .replace('{commit}', commit.commit.short)
+          }
+        })
+        return acc
+      }, {})
     }
 
     Object.values(this._context.commits)

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "sinon": "^8.1.1"
       },
       "peerDependencies": {
-        "semantic-release": "<22"
+        "semantic-release": "<23"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "commit": "gitmoji -c",
     "lint": "eslint ./index.js ./lib/**/*.js",
     "link": "npm link && npm link semantic-release-gitmoji",
-    "test": "ava test/**/*.test.js"
+    "test": "ava test/**/*.test.js --verbose"
   },
   "repository": {
     "type": "git",

--- a/test/integration/analyze-commits.test.js
+++ b/test/integration/analyze-commits.test.js
@@ -15,35 +15,56 @@ test.after(function () {
   stub.restore()
 })
 
+const commitUrlTemplate = 'https://{source}/{owner}/{repo}/commit/{commit}';
+
 const CASES = [
   {
     name: 'default config + common context w/o updates',
-    pluginConfig: {},
+    pluginConfig: {
+      releaseNotes: {
+        commitUrlTemplate
+      }
+    },
     context: getContext('common', { commits: { boring: 2 } }),
     expectedRelease: undefined
   },
   {
     name: 'default config + common context w/ patch updates',
-    pluginConfig: {},
+    pluginConfig: {
+      releaseNotes: {
+        commitUrlTemplate
+      }
+    },
     context: getContext('common', { commits: { boring: 2, patch: 4 } }),
     expectedRelease: 'patch'
   },
   {
     name: 'default config + common context w/ minor updates',
-    pluginConfig: {},
+    pluginConfig: {
+      releaseNotes: {
+        commitUrlTemplate
+      }
+    },
     context: getContext('common', { commits: { boring: 2, patch: 4, minor: 2 } }),
     expectedRelease: 'minor'
   },
   {
     name: 'default config + common context w/ major updates',
-    pluginConfig: {},
+    pluginConfig: {
+      releaseNotes: {
+        commitUrlTemplate
+      }
+    },
     context: getContext('common', { commits: { boring: 2, patch: 4, minor: 2, major: 1 } }),
     expectedRelease: 'major'
   },
   {
     name: 'default config + common context w/o updates using gitmoji semver',
     pluginConfig: {
-      semver: true
+      semver: true,
+      releaseNotes: {
+        commitUrlTemplate
+      }
     },
     context: getContext('common', { commits: { boring: 2 } }),
     expectedRelease: undefined
@@ -51,7 +72,10 @@ const CASES = [
   {
     name: 'default config + common context w/ patch updates using gitmoji semver',
     pluginConfig: {
-      semver: true
+      semver: true,
+      releaseNotes: {
+        commitUrlTemplate
+      }
     },
     context: getContext('common', { commits: { boring: 2, patch: 4 } }),
     expectedRelease: 'patch'
@@ -59,7 +83,10 @@ const CASES = [
   {
     name: 'default config + common context w/ minor updates using gitmoji semver',
     pluginConfig: {
-      semver: true
+      semver: true,
+      releaseNotes: {
+        commitUrlTemplate
+      }
     },
     context: getContext('common', { commits: { boring: 2, patch: 4, minor: 2 } }),
     expectedRelease: 'minor'
@@ -67,7 +94,10 @@ const CASES = [
   {
     name: 'default config + common context w/ major updates using gitmoji semver',
     pluginConfig: {
-      semver: true
+      semver: true,
+      releaseNotes: {
+        commitUrlTemplate
+      }
     },
     context: getContext('common', { commits: { boring: 2, patch: 4, minor: 2, major: 1 } }),
     expectedRelease: 'major'

--- a/test/integration/generate-notes.test.js
+++ b/test/integration/generate-notes.test.js
@@ -28,10 +28,16 @@ test.after(function () {
   stub.restore()
 })
 
+const commitUrlTemplate = 'https://{source}/{owner}/{repo}/commit/{commit}'
+
 const CASES = [
   {
     name: 'default config + common context w/ patch updates',
-    pluginConfig: {},
+    pluginConfig: {
+      releaseNotes: {
+        commitUrlTemplate
+      }
+    },
     context: getContext('common', {
       commits: { boring: 2, patch: 4 },
       nextRelease: {
@@ -43,7 +49,11 @@ const CASES = [
   },
   {
     name: 'default config + common context w/ minor updates',
-    pluginConfig: {},
+    pluginConfig: {
+      releaseNotes: {
+        commitUrlTemplate
+      }
+    },
     context: getContext('common', {
       commits: { boring: 2, patch: 4, minor: 2 },
       nextRelease: {
@@ -55,7 +65,11 @@ const CASES = [
   },
   {
     name: 'default config + common context w/ major updates',
-    pluginConfig: {},
+    pluginConfig: {
+      releaseNotes: {
+        commitUrlTemplate
+      }
+    },
     context: getContext('common', {
       commits: { boring: 2, patch: 4, minor: 2, major: 1 },
       nextRelease: {
@@ -67,7 +81,11 @@ const CASES = [
   },
   {
     name: 'default config + WIP context w/ minor updates',
-    pluginConfig: {},
+    pluginConfig: {
+      releaseNotes: {
+        commitUrlTemplate
+      }
+    },
     context: getContext('wip', {
       nextRelease: {
         version: '1.0.0',
@@ -81,6 +99,7 @@ const CASES = [
     pluginConfig: {
       releaseNotes: {
         template: '{{capitalize "cUSTOM"}} Helpers',
+        commitUrlTemplate,
         helpers: {
           capitalize: function (str = '') {
             return str.length > 0 ? str[0].toUpperCase() + str.slice(1).toLowerCase() : str
@@ -101,6 +120,7 @@ const CASES = [
     name: 'default config + custom issueResolution',
     pluginConfig: {
       releaseNotes: {
+        commitUrlTemplate,
         issueResolution: {
           removeFromCommit: true,
           regex: /CUSTOM-\d{4}/g,
@@ -121,6 +141,7 @@ const CASES = [
     pluginConfig: {
       releaseNotes: {
         semver: true,
+        commitUrlTemplate,
         template: template
       }
     },
@@ -138,6 +159,7 @@ const CASES = [
     pluginConfig: {
       releaseNotes: {
         semver: true,
+        commitUrlTemplate,
         template
       }
     },
@@ -155,6 +177,7 @@ const CASES = [
     pluginConfig: {
       releaseNotes: {
         semver: true,
+        commitUrlTemplate,
         template
       }
     },
@@ -172,6 +195,7 @@ const CASES = [
     pluginConfig: {
       releaseNotes: {
         semver: true,
+        commitUrlTemplate,
         template
       }
     },
@@ -188,6 +212,7 @@ const CASES = [
     pluginConfig: {
       releaseNotes: {
         semver: true,
+        commitUrlTemplate,
         template,
         issueResolution: {
           removeFromCommit: true,


### PR DESCRIPTION
This commit introduces the ability to customize commit URLs and issue resolution in release notes. It also adds support for GitLab and Bitbucket comparison links. The changes include updates to the default configuration, release notes generation, and test cases. The commit URL is now generated using a string template, and issue references in commit messages can be resolved based on a custom configuration.