### PR TITLE
⬆️ Support semantic release v23

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "node-emoji": "^1.11.0"
   },
   "peerDependencies": {
-    "semantic-release": "<23"
+    "semantic-release": "<24"
   },
   "files": [
     "lib",


### PR DESCRIPTION
A simple change in the peerDependencies

FYI v23 has been released in Jan 2024
https://github.com/semantic-release/semantic-release/releases/tag/v23.0.0


# Test

- [ci test are ok](https://github.com/linuxidefix/semantic-release-gitmoji/actions/runs/9044352539/job/24852907230)


# Issue
Close #99 