### PR TITLE
:bug: Fix mis-recognizing character '*' as a gitmoji

### DIFF
--- a/lib/helper/parse-commits.js
+++ b/lib/helper/parse-commits.js
@@ -1,5 +1,6 @@
 const issueRegex = require('issue-regex')
-const emojiRegex = require('emoji-regex/text')
+const emojiRegex = require('emoji-regex')
+const escapeStringRegex = require('escape-string-regexp')
 const { emojify } = require('node-emoji')
 const { gitmojis } = require('gitmojis')
 
@@ -48,7 +49,7 @@ function parseGitmoji ({ subject = '', message = '', body = '' } = {}, issues = 
 
   const gitmoji = matched[0]
   const semver = gitmojis.find(matchEmoji(gitmoji))?.semver || 'other'
-  subject = subject.replace(new RegExp('^' + gitmoji), '')
+  subject = subject.replace(new RegExp('^' + escapeStringRegex(gitmoji)), '')
 
   return { subject, message: subject + '\n\n' + body, gitmoji, semver }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
       "dependencies": {
         "dateformat": "^3.0.3",
         "debug": "^4.3.2",
-        "emoji-regex": "^9.2.2",
+        "emoji-regex": "^10.3.0",
+        "escape-string-regexp": "^4.0.0",
         "git-url-parse": "^13.0.0",
         "gitmojis": "^3.13.4",
         "handlebars": "^4.7.6",
@@ -103,6 +104,15 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/@babel/highlight/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.0"
       }
     },
     "node_modules/@babel/highlight/node_modules/has-flag": {
@@ -1692,6 +1702,12 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/boxen/node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true
+    },
     "node_modules/boxen/node_modules/string-width": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
@@ -2118,6 +2134,12 @@
       "funding": {
         "url": "https://github.com/chalk/ansi-regex?sponsor=1"
       }
+    },
+    "node_modules/cli-truncate/node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true
     },
     "node_modules/cli-truncate/node_modules/string-width": {
       "version": "5.1.2",
@@ -2887,9 +2909,9 @@
       }
     },
     "node_modules/emoji-regex": {
-      "version": "9.2.2",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
-      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.3.0.tgz",
+      "integrity": "sha512-QpLs9D9v9kArv4lfDEgg1X/gN5XLnf/A6l9cs8SPZLRZR3ZkY9+kwIQTxm+fsSej5UMYGE8fdoaZVIBlqG0XTw=="
     },
     "node_modules/emojilib": {
       "version": "2.4.0",
@@ -3150,12 +3172,14 @@
       }
     },
     "node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "dev": true,
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
       "engines": {
-        "node": ">=0.8.0"
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/escodegen": {
@@ -3493,18 +3517,6 @@
       "dev": true,
       "dependencies": {
         "@babel/highlight": "^7.10.4"
-      }
-    },
-    "node_modules/eslint/node_modules/escape-string-regexp": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-      "dev": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/eslint/node_modules/eslint-visitor-keys": {
@@ -8930,12 +8942,6 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
-    "node_modules/ora/node_modules/emoji-regex": {
-      "version": "10.3.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.3.0.tgz",
-      "integrity": "sha512-QpLs9D9v9kArv4lfDEgg1X/gN5XLnf/A6l9cs8SPZLRZR3ZkY9+kwIQTxm+fsSej5UMYGE8fdoaZVIBlqG0XTw==",
-      "dev": true
-    },
     "node_modules/ora/node_modules/string-width": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-6.1.0.tgz",
@@ -10322,6 +10328,15 @@
         "node": ">=4"
       }
     },
+    "node_modules/signale/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
     "node_modules/signale/node_modules/figures": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
@@ -11381,6 +11396,12 @@
       "funding": {
         "url": "https://github.com/chalk/ansi-regex?sponsor=1"
       }
+    },
+    "node_modules/widest-line/node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true
     },
     "node_modules/widest-line/node_modules/string-width": {
       "version": "5.1.2",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
   "dependencies": {
     "dateformat": "^3.0.3",
     "debug": "^4.3.2",
-    "emoji-regex": "^9.2.2",
+    "emoji-regex": "^10.3.0",
+    "escape-string-regexp": "^4.0.0",
     "git-url-parse": "^13.0.0",
     "gitmojis": "^3.13.4",
     "handlebars": "^4.7.6",


### PR DESCRIPTION
Close #76 
Replace #85 

- Change import from 'emoji-regex/text' to 'emoji-regex' since the latest version of package emoji-regex does not export 'emoji-regex/text'
- Escape regexp with the help of package escape-string-regexp